### PR TITLE
fix(package): use array type for locale option

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 - `rainbow-fart.enabled`: Enable extension, default: `true`
 - `rainbow-fart.trace.server`: Trace level of log, default: `off`
-- `rainbow-fart.locale`: Enable locale of voice package, default: `['zh']`
+- `rainbow-fart.locale`: Enable locale of voice package, default: `["zh"]`
 - `rainbow-fart.ffplay`: ffplay Command, default: `''`
   > will download ffplay from https://ffbinaries.com/downloads if empty.
 - `rainbow-fart.voice-packages`: Add your own voice packages, default: `[]`

--- a/package.json
+++ b/package.json
@@ -47,8 +47,10 @@
           "description": "Trace level of log"
         },
         "rainbow-fart.locale": {
-          "type": "string",
-          "default": "['zh']",
+          "type": "array",
+          "default": [
+            "zh"
+          ],
           "item": "string",
           "description": "Enable locale of voice package"
         },


### PR DESCRIPTION
Though type "string" works normally, type "array" would be better. :smile: 

(Guess a mistake caused by the carelessness while typing)